### PR TITLE
Change deprecated and supressed method

### DIFF
--- a/lib/redmine_issue_tabs/issues_controller_patch.rb
+++ b/lib/redmine_issue_tabs/issues_controller_patch.rb
@@ -4,7 +4,7 @@ module RedmineIssueTabs
       base.send(:include, InstanceMethods)
 
       base.class_eval do
-        before_filter :get_time_entries, only: [:show]
+        before_action :get_time_entries, only: [:show]
       end
     end
 


### PR DESCRIPTION
- before_filter to before_action because before_filter was deleted since RubyOnRails 2.3.8